### PR TITLE
Support direct nesting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 [CSS Nesting] allows you to nest one style rule inside another, following the [CSS Nesting Module Level 3] specification.
 
+### At Rule Nesting
 ```css
-/* before */
+/* at rule nesting */
 
 a, b {
 	color: red;
@@ -19,6 +20,28 @@ a, b {
 	}
 
 	@nest &:hover {
+		color: black;
+	}
+
+	@media (min-width: 30em) {
+		color: yellow;
+	}
+}
+
+/* direct nesting */
+
+a, b {
+	color: red;
+
+	& c, & d {
+		color: white;
+	}
+
+	& & {
+		color: blue;
+	}
+
+	&:hover {
 		color: black;
 	}
 

--- a/index.js
+++ b/index.js
@@ -58,5 +58,17 @@ module.exports = postcss.plugin('postcss-nested', function (opts) {
 				}
 			}
 		});
+
+		css.walkRules(function (rule) {
+			if (rule.parent.type === 'root' || rule.selector.indexOf('&') === -1) return;
+
+			transpileSelectors(rule.parent, rule);
+
+			rule.moveAfter(rule.parent);
+
+			if (!rule.prev().nodes.length) {
+				rule.prev().remove();
+			}
+		});
 	};
 });

--- a/test/fixtures/direct.css
+++ b/test/fixtures/direct.css
@@ -1,0 +1,79 @@
+a, b {
+	color: white;
+
+	& c, & d {
+		color: blue
+	}
+}
+
+a, b {
+	color: white;
+
+	& c, & d {
+		color: blue;
+
+		& e, & f {
+			color: black
+		}
+	}
+}
+
+a, b {
+	color: red;
+
+	& & {
+		color: white
+	}
+}
+
+a {
+	color: red;
+
+	@media {
+		color: white
+	}
+}
+
+a {
+	color: red;
+
+	& b {
+		color: white;
+
+		@media {
+			color: blue
+		}
+	}
+
+	@media {
+		color: black;
+
+		& c {
+			color: yellow
+		}
+	}
+}
+
+a {
+	color: red;
+
+	@unknown test {
+		color: white
+	}
+}
+
+b {
+	color: white;
+
+	@phone {
+		color: blue
+	}
+
+	@media {
+		color: black;
+
+		& c {
+			color: yellow
+		}
+	}
+}

--- a/test/fixtures/direct.expect.css
+++ b/test/fixtures/direct.expect.css
@@ -1,0 +1,91 @@
+a, b {
+	color: white
+}
+
+a c, a d, b c, b d {
+	color: blue
+}
+
+a, b {
+	color: white
+}
+
+a c, a d, b c, b d {
+	color: blue
+}
+
+a c e, a c f, a d e, a d f, b c e, b c f, b d e, b d f {
+	color: black
+}
+
+a, b {
+	color: red
+}
+
+a a, b b {
+	color: white
+}
+
+a {
+	color: red
+}
+
+@media {
+
+	a {
+		color: white
+	}
+	}
+
+a {
+	color: red
+}
+
+a b {
+	color: white
+}
+
+@media {
+
+	a b {
+		color: blue
+	}
+		}
+
+@media {
+
+	a {
+		color: black
+	}
+
+	a c {
+		color: yellow
+	}
+	}
+
+a {
+	color: red;
+
+	@unknown test {
+		color: white
+	}
+}
+
+b {
+	color: white;
+
+	@phone {
+		color: blue
+	}
+}
+
+@media {
+
+	b {
+		color: black
+	}
+
+	b c {
+		color: yellow
+	}
+	}

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -1,7 +1,7 @@
 a, b {
 	color: white;
 
-	& c, & d {
+	c, d {
 		color: blue;
 	}
 }
@@ -12,4 +12,8 @@ a, b {
 	@nest c, d {
 		color: blue;
 	}
+}
+
+& a {
+	color: white;
 }

--- a/test/fixtures/ignore.expect.css
+++ b/test/fixtures/ignore.expect.css
@@ -1,7 +1,7 @@
 a, b {
 	color: white;
 
-	& c, & d {
+	c, d {
 		color: blue;
 	}
 }
@@ -12,4 +12,8 @@ a, b {
 	@nest c, d {
 		color: blue;
 	}
+}
+
+& a {
+	color: white;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,9 @@ var tests = {
 		'basic': {
 			message: 'supports basic usage'
 		},
+		'direct': {
+			message: 'supports direct nesting'
+		},
 		'ignore': {
 			message: 'ignores invalid syntax'
 		}


### PR DESCRIPTION
This commit is to allows support for direct nesting per [the proposed spec](https://tabatkins.github.io/specs/css-nesting/)

In this commit I:
- add `walkRules` method
- update `ignore` tests for new methods
- add direct nesting test.

This should close #10 