### PR TITLE
Change plugin name to postcss-nesting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var postcss = require('postcss');
 
-module.exports = postcss.plugin('postcss-nested', function (opts) {
+module.exports = postcss.plugin('postcss-nesting', function (opts) {
 	var bubble = ['document', 'media', 'supports'];
 	var name   = 'nest';
 


### PR DESCRIPTION
I found it very confusing when I saw that this plugin was registering its name as postcss-nested instead of postcss-nesting. Does this seem like a reasonable change to you?