### PR TITLE
fix: a case in which test rule will compose another valid CSS qualified name

### DIFF
--- a/lib/transform-nesting-atrule.js
+++ b/lib/transform-nesting-atrule.js
@@ -39,5 +39,5 @@ module.exports = (node) => {
 
 // whether the node is a nesting atrule (e.g. @nest .something &)
 module.exports.test = (node) => node.type === 'atrule' && node.name === 'nest' && node.parent && node.parent.type === 'rule' && comma(node.params).every(
-	(selector) => selector.split('&').length === 2 && /&([^\w-]|$)/.test(selector)
+	(selector) => selector.split('&').length === 2 && /&([^\w-|]|$)/.test(selector)
 );

--- a/lib/transform-nesting-rule.js
+++ b/lib/transform-nesting-rule.js
@@ -25,5 +25,5 @@ module.exports = (node) => {
 
 // whether the node is a nesting rule (e.g. &.something)
 module.exports.test = (node) => node.type === 'rule' && node.parent && node.parent.type === 'rule' && node.selectors.every(
-	(selector) => selector.trim().lastIndexOf('&') === 0 && /^&([^\w-]|$)/.test(selector)
+	(selector) => selector.trim().lastIndexOf('&') === 0 && /^&([^\w-|]|$)/.test(selector)
 );

--- a/test/ignore.css
+++ b/test/ignore.css
@@ -31,4 +31,7 @@ f {
 	@nest &h {
 		order: 5;
 	}
+	@nest &|i {
+		order: 6;
+	}
 }

--- a/test/ignore.expect.css
+++ b/test/ignore.expect.css
@@ -31,4 +31,7 @@ f {
 	@nest &h {
 		order: 5;
 	}
+	@nest &|i {
+		order: 6;
+	}
 }


### PR DESCRIPTION
To be nest-containing, any nesting selector must composed with other selectors into a valid complex selectors. However, the current implementation will turn
```css
a { &|b { } }
```
into
```css
a|b { }
```
which is a valid CSS rule with simple selector. We should reject the vertical bar on selector validity test.