### PR TITLE
Use mutation-safe walk method

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -3,6 +3,9 @@ module.exports = {
 		'basic': {
 			message: 'supports basic usage'
 		},
+		'at-rule': {
+			message: 'supports at-rule usage'
+		},
 		'direct': {
 			message: 'supports direct usage'
 		},

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const transformNestingRule    = require('./lib/transform-nesting-rule');
 
 // plugin
 module.exports = postcss.plugin('postcss-nesting', () => {
-	return walk;
+	return (root) => root.walk(transform);
 });
 
-function walk(node) {
+function transform(node) {
 	// console.log('walk', [node.type], [node.name || node.selector || node.prop || 'root'], node.nodes ? `length: ${node.nodes.length}` : `value: "${node.value}"`);
 
 	if (transformBubblingAtrule.test(node)) {
@@ -25,14 +25,4 @@ function walk(node) {
 		transformNestingRule(node);
 	}
 
-	if (node.nodes) {
-		// conditionally walk the children of the node
-		let childNode = node.nodes[0];
-
-		while (childNode) {
-			walk(childNode);
-
-			childNode = childNode.parent && childNode.parent.nodes[childNode.parent.nodes.indexOf(childNode) + 1];
-		}
-	}
 }

--- a/lib/transform-nesting-atrule.js
+++ b/lib/transform-nesting-atrule.js
@@ -20,6 +20,9 @@ module.exports = (node) => {
 		source: node.source
 	});
 
+	// clone atrule semicolon raws
+	rule.raws = node.raws.semicolon ? { semicolon: true } : {};
+
 	// move the clone after the parent
 	const parent = node.parent.after(rule);
 

--- a/test/at-rule.css
+++ b/test/at-rule.css
@@ -1,0 +1,30 @@
+a {
+	order: 1;
+	@nest b & {
+		order: 2;
+	}
+	@nest c & {
+		order: 3;
+	}
+	@nest d & {
+		order: 4;
+	}
+	@nest e & {
+		order: 5;
+	}
+}
+a {
+	order: 1;
+	@nest & b {
+		order: 2;
+	}
+	@nest & c {
+		order: 3;
+	}
+	@nest & d {
+		order: 4;
+	}
+	@nest & e {
+		order: 5;
+	}
+}

--- a/test/at-rule.expect.css
+++ b/test/at-rule.expect.css
@@ -1,0 +1,30 @@
+a {
+	order: 1
+}
+b a {
+	order: 2;
+}
+c a {
+	order: 3;
+}
+d a {
+	order: 4;
+}
+e a {
+	order: 5;
+}
+a {
+	order: 1
+}
+a b {
+	order: 2;
+}
+a c {
+	order: 3;
+}
+a d {
+	order: 4;
+}
+a e {
+	order: 5;
+}


### PR DESCRIPTION
Fix #40, #42 

Refactored to use `root.walk` instead of handwritten conditional walk. Written new tests to cover #40, all test passed.

If there is any caveat of using handwritten walk method, feel free to correct me.