### PR TITLE
Support postcss 8

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -1,22 +1,20 @@
 module.exports = {
-	'postcss-nesting': {
-		'basic': {
-			message: 'supports basic usage'
-		},
-		'at-rule': {
-			message: 'supports at-rule usage'
-		},
-		'direct': {
-			message: 'supports direct usage'
-		},
-		'empty': {
-			message: 'removes empty rules'
-		},
-		'media': {
-			message: 'supports nested media'
-		},
-		'ignore': {
-			message: 'ignores invalid entries'
-		}
+	'basic': {
+		message: 'supports basic usage'
+	},
+	'at-rule': {
+		message: 'supports at-rule usage'
+	},
+	'direct': {
+		message: 'supports direct usage'
+	},
+	'empty': {
+		message: 'removes empty rules'
+	},
+	'media': {
+		message: 'supports nested media'
+	},
+	'ignore': {
+		message: 'ignores invalid entries'
 	}
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 6
+  - 10
 
 install:
   - npm install --ignore-scripts

--- a/index.js
+++ b/index.js
@@ -1,4 +1,14 @@
-import postcss from 'postcss';
 import walk from './lib/walk';
 
-export default postcss.plugin('postcss-nesting', () => walk);
+const postcssNesting = () => {
+	return {
+		postcssPlugin: 'postcss-nesting',
+		Once(root) {
+			walk(root);
+		}
+	}
+}
+
+postcssNesting.postcss = true;
+
+export default postcssNesting;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
     "test:tape": "postcss-tape"
   },
   "engines": {
-    "node": ">=6.0.0"
-  },
-  "dependencies": {
-    "postcss": "^7.0.2"
+    "node": ">=10.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -33,7 +30,8 @@
     "babel-plugin-array-includes": "^2.0.3",
     "eslint": "^5.6.0",
     "eslint-config-dev": "^2.0.0",
-    "postcss-tape": "^2.2.0",
+    "postcss": "^8.1.2",
+    "postcss-tape": "^6.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^0.66.0",
     "rollup-plugin-babel": "^4.0.1"
@@ -41,6 +39,9 @@
   "eslintConfig": {
     "extends": "dev",
     "parser": "babel-eslint"
+  },
+  "peerDependencies": {
+    "postcss": "^8.1.2"
   },
   "keywords": [
     "postcss",


### PR DESCRIPTION
Update plugin to support postcss 8, followed the migration guide available [here](https://evilmartians.com/chronicles/postcss-8-plugin-migration).

* update to postcss@8
* move "postcss" to peerDependencies
* updated plugin syntax
* update postcss-tape to latest
* update `.tape.js` config syntax
* drop node 6/8 support, updated "node.engines" field and travis.yml