### PR TITLE
fix #82: use the RuleExit listener

### DIFF
--- a/src/lib/walk.js
+++ b/src/lib/walk.js
@@ -4,21 +4,19 @@ import transformAtruleWithinRule, { isAtruleWithinRule } from './atrule-within-r
 import transformAtruleWithinAtrule, { isAtruleWithinAtrule } from './atrule-within-atrule.js'
 
 export default function walk(node) {
-	node.nodes.slice(0).forEach((child) => {
-		if (child.parent === node) {
-			if (isRuleWithinRule(child)) {
-				transformRuleWithinRule(child)
-			} else if (isNestRuleWithinRule(child)) {
-				transformNestRuleWithinRule(child)
-			} else if (isAtruleWithinRule(child)) {
-				transformAtruleWithinRule(child)
-			} else if (isAtruleWithinAtrule(child)) {
-				transformAtruleWithinAtrule(child)
-			}
+	node.each((child) => {
+		if (isRuleWithinRule(child)) {
+			transformRuleWithinRule(child)
+		} else if (isNestRuleWithinRule(child)) {
+			transformNestRuleWithinRule(child)
+		} else if (isAtruleWithinRule(child)) {
+			transformAtruleWithinRule(child)
+		} else if (isAtruleWithinAtrule(child)) {
+			transformAtruleWithinAtrule(child)
+		}
 
-			if (Object(child.nodes).length) {
-				walk(child)
-			}
+		if (Object(child.nodes).length) {
+			walk(child)
 		}
 	})
 }

--- a/src/postcss-8-nesting.js
+++ b/src/postcss-8-nesting.js
@@ -3,8 +3,8 @@ import walk from './lib/walk.js'
 export default function postcssNesting() {
 	return {
 		postcssPlugin: 'postcss-nesting',
-		Once(root) {
-			walk(root)
+		RuleExit(rule) {
+			walk(rule)
 		},
 	}
 }

--- a/test/mixin.css
+++ b/test/mixin.css
@@ -1,0 +1,6 @@
+a {
+	& b {
+		color: red;
+	}
+	@mixin;
+}

--- a/test/mixin.expect.css
+++ b/test/mixin.expect.css
@@ -1,0 +1,5 @@
+
+	a b {
+		color: red;
+	}
+a .in.deep { color: blue; }


### PR DESCRIPTION
this allows to use postcss-mixins again
fixes: #82
see also:
https://github.com/postcss/postcss-mixins/issues/123
https://github.com/postcss/postcss-nested/issues/101